### PR TITLE
Fix misra 13 2 update 1

### DIFF
--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -61,7 +61,8 @@
         /* Is the currently saved stack pointer within the stack limit? */                            \
         if( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING )           \
         {                                                                                             \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pxCurrentTCB->pcTaskName ); \
+            char * pcTasOverflowTaskName = pxCurrentTCB->pcTaskName;                                  \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcTasOverflowTaskName );    \
         }                                                                                             \
     } while( 0 )
 
@@ -77,7 +78,8 @@
         /* Is the currently saved stack pointer within the stack limit? */                            \
         if( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING )      \
         {                                                                                             \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pxCurrentTCB->pcTaskName ); \
+            char * pcTasOverflowTaskName = pxCurrentTCB->pcTaskName;                                  \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcTasOverflowTaskName );    \
         }                                                                                             \
     } while( 0 )
 
@@ -96,7 +98,8 @@
             ( pulStack[ 2 ] != ulCheckValue ) ||                                                      \
             ( pulStack[ 3 ] != ulCheckValue ) )                                                       \
         {                                                                                             \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pxCurrentTCB->pcTaskName ); \
+            char * pcTasOverflowTaskName = pxCurrentTCB->pcTaskName;                                  \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcTasOverflowTaskName );    \
         }                                                                                             \
     } while( 0 )
 
@@ -120,7 +123,8 @@
         /* Has the extremity of the task stack ever been written over? */                                                                 \
         if( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 )                     \
         {                                                                                                                                 \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pxCurrentTCB->pcTaskName );                                     \
+            char * pcTasOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                      \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcTasOverflowTaskName );                                        \
         }                                                                                                                                 \
     } while( 0 )
 

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -61,8 +61,8 @@
         /* Is the currently saved stack pointer within the stack limit? */                            \
         if( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING )           \
         {                                                                                             \
-            char * pcTasOverflowTaskName = pxCurrentTCB->pcTaskName;                                  \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcTasOverflowTaskName );    \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                     \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );       \
         }                                                                                             \
     } while( 0 )
 
@@ -78,8 +78,8 @@
         /* Is the currently saved stack pointer within the stack limit? */                            \
         if( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING )      \
         {                                                                                             \
-            char * pcTasOverflowTaskName = pxCurrentTCB->pcTaskName;                                  \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcTasOverflowTaskName );    \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                     \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );       \
         }                                                                                             \
     } while( 0 )
 
@@ -98,8 +98,8 @@
             ( pulStack[ 2 ] != ulCheckValue ) ||                                                      \
             ( pulStack[ 3 ] != ulCheckValue ) )                                                       \
         {                                                                                             \
-            char * pcTasOverflowTaskName = pxCurrentTCB->pcTaskName;                                  \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcTasOverflowTaskName );    \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                     \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );       \
         }                                                                                             \
     } while( 0 )
 
@@ -123,8 +123,8 @@
         /* Has the extremity of the task stack ever been written over? */                                                                 \
         if( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 )                     \
         {                                                                                                                                 \
-            char * pcTasOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                      \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcTasOverflowTaskName );                                        \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                         \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );                                           \
         }                                                                                                                                 \
     } while( 0 )
 


### PR DESCRIPTION
Fix stack macro overflow check volatile access

Description
-----------
Enable `configCHECK_FOR_STACK_OVERFLOW `. This error will be reported.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
